### PR TITLE
changed aerogear-crypto jar dependency from source-file to lib-file

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -34,7 +34,7 @@
 
     <source-file src="src/android/org/jboss/aerogear/cordova/crypto/CryptoPlugin.java" target-dir="src/org/jboss/aerogear/cordova/crypto/"/>
 
-    <source-file src="src/android/libs/aerogear-crypto-0.1.5-android.jar" target-dir="libs"/>
+    <lib-file src="src/android/libs/aerogear-crypto-0.1.5-android.jar"></lib-file>
   </platform>
 
   <!-- ios -->


### PR DESCRIPTION
I changed the plugin.xml so it uses lib-file instead of source-file for the aerogear-crypto-0.1.5-android.jar dependency.
This is more correct and makes the plugin usable with cordova-android 7.x